### PR TITLE
Add Pre-commit hook for branch naming to the Django Cookie Cutter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,9 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+    -   id: no-commit-to-branch
+        args: ['--pattern', '^(?!([a-zA-Z]+/[0-9]+-.*)$).*']
+
 
 -   repo: https://github.com/psf/black
     rev: 22.8.0


### PR DESCRIPTION

ERROR MESSAGE LOOKS LIKE:-

```
git commit -m "branch naming restriction to pre-commit hook."
Check Yaml...............................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
Don't commit to branch...................................................Failed
- hook id: no-commit-to-branch
- exit code: 1
black................................................(no files to check)Skipped
isort................................................(no files to check)Skipped
Check django migrations..............................(no files to check)Skipped
```

VALID BRANCH NAME SAMPLES:-

- cmaliwal/203-test
- cmaliwal/204-test_branch
