### PR TITLE
fix: add secrets-config secret for local dev. close #175

### DIFF
--- a/{{cookiecutter.project_slug}}/k8s/local/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/local/kustomization.yaml
@@ -5,3 +5,4 @@ bases:
  - ../base
 resources:
 - ./postgres.yaml
+- ./secrets.yaml

--- a/{{cookiecutter.project_slug}}/k8s/local/secrets.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/local/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+stringData:
+  POSTGRES_PASSWORD: {{ cookiecutter.project_slug }}
+  POSTGRES_HOST: postgres
+  POSTGRES_USER: {{ cookiecutter.project_slug }}
+  DATABASE_URL: postgresql://{{ cookiecutter.project_slug }}:{{ cookiecutter.project_slug }}@postgres/{{ cookiecutter.project_slug }}
+  DJANGO_SECRET_KEY: local
+kind: Secret
+metadata:
+  name: secrets-config
+type: Opaque


### PR DESCRIPTION
This PR fixes the secrets-config not found error encountered when starting Tilt for local development.