### PR TITLE
Changes to correct requirement for sentry - #177 

### DIFF
--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -3,8 +3,8 @@
 export AWS_ACCESS_KEY_SES=$(op read "op://{{cookiecutter.project_name}}/AWS_ACCESS_KEY_SES/token")
 export AWS_SECRET_KEY_SES=$(op read "op://{{cookiecutter.project_name}}/AWS_SECRET_KEY_SES/token")
 export POSTGRES_PASSWORD=$(op read "op://{{cookiecutter.project_name}}/POSTGRES_DB/password")
-export POSTGRES_USER=$(op read "op://{{cookiecutter.project_name}}/POSTGERS_DB/username")
+export POSTGRES_USER=$(op read "op://{{cookiecutter.project_name}}/POSTGRES_DB/username")
 # use sandbox host for secrets generation
-export POSTGRES_HOST=db-rw
+export POSTGRES_HOST=postgres
 export DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/{{ cookiecutter.project_slug }}
 export DJANGO_SECRET_KEY=$(op read "op://{{cookiecutter.project_name}}/DJANGO_SECRET_KEY/token")

--- a/{{cookiecutter.project_slug}}/.envrc
+++ b/{{cookiecutter.project_slug}}/.envrc
@@ -8,7 +8,3 @@ export POSTGRES_USER=$(op read "op://{{cookiecutter.project_name}}/POSTGERS_DB/u
 export POSTGRES_HOST=db-rw
 export DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/{{ cookiecutter.project_slug }}
 export DJANGO_SECRET_KEY=$(op read "op://{{cookiecutter.project_name}}/DJANGO_SECRET_KEY/token")
-{% if cookiecutter.use_sentry == 'y' %}
-export SENTRY_DSN_BACKEND=$(op read "op://{{cookiecutter.project_name}}/SENTRY_DSN_BACKEND/token")
-export SENTRY_DSN_FRONTEND=$(op read "op://{{cookiecutter.project_name}}/SENTRY_DSN_FRONTEND/token")
-{% endif %}

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -132,7 +132,7 @@ Note: The values for both tokens can be empty if you don't wish to use Sentry.
    2. One project for the frontend 
 2. Configure Slack notifications
 3. Add team members in Sentry 
-4. Update `k8s/base/django.configmap.yaml` `SENTRY_DSN_BACKEND`, `VITE_SENTRY_DSN_FRONTEND` with the DSNs appropriate for the relevant Sentry projects. 
+4. Update `k8s/base/app.configmap.yaml` `SENTRY_DSN_BACKEND`, `VITE_SENTRY_DSN_FRONTEND` with the DSNs appropriate for the relevant Sentry projects. 
 
 For more detailed steps view `./docs/sentry.md`
 

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -132,9 +132,7 @@ Note: The values for both tokens can be empty if you don't wish to use Sentry.
    2. One project for the frontend 
 2. Configure Slack notifications
 3. Add team members in Sentry 
-4. Update `django.configmap.yaml` SENTRY_DSN_BACKEND with the DSN provided in the Sentry backend project 
-5. Update `.env` SENTRY_DSN_FRONTEND with the DSN provided in the Sentry frontend project
-
+4. Update `k8s/base/django.configmap.yaml` `SENTRY_DSN_BACKEND`, `VITE_SENTRY_DSN_FRONTEND` with the DSNs appropriate for the relevant Sentry projects. 
 
 For more detailed steps view `./docs/sentry.md`
 

--- a/{{cookiecutter.project_slug}}/backend/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/backend/config/settings/base.py
@@ -324,9 +324,9 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # ------------------------------------------------------------------------------
 # Sentry
 sentry_sdk.init(
-    dsn=env('SENTRY_DSN_BACKEND', ''),
-    environment=env('ENVIRONMENT','production'),
-    release=env('RELEASE', 'dev'),
+    dsn=env.str("SENTRY_DSN_BACKEND", default=""),
+    environment=env.str("ENVIRONMENT", default="production"),
+    release=env.str("RELEASE", default="dev"),
 )
 {% endif %}
 

--- a/{{cookiecutter.project_slug}}/docs/sentry.md
+++ b/{{cookiecutter.project_slug}}/docs/sentry.md
@@ -34,16 +34,18 @@
 
 ### Add code to Django
 
-Make sure the following is to your preferences in all logical locations in the `backend/config/settings/{environment}.py` files that you set up as Projects in Sentry:
+By default this is in the base config. Make sure the following is to your preferences in all logical locations in the `backend/config/settings/{environment}.py` files:
+
 ```
     import sentry_sdk
     ...
     sentry_sdk.init(
-        dsn=env('SENTRY_DSN_BACKEND', ''),
-        environment=env('ENVIRONMENT','production'),
-        release=env('RELEASE',''),
+        dsn=env.str("SENTRY_DSN_BACKEND", default=""),
+        environment=env.str("ENVIRONMENT", default="production"),
+        release=env.str("RELEASE", default="dev"),
     )
 ```
-Make sure you have the correct `SENTRY_DSN_BACKEND` and `SENTRY_DSN_FRONTEND` tokens set up in 1password .envrc with the Sentry project DSNs for this project. The same Sentry projects should be used across all environments
+
+Update `k8s/base/django.configmap.yaml` `SENTRY_DSN_BACKEND`, `VITE_SENTRY_DSN_FRONTEND` with the DSNs provided for the relevant Sentry projects. 
 
 You can find them in Sentry by clicking Settings on the sidebar, then Projects on the secondary sidebar, then the project, then Client Keys (DSN)

--- a/{{cookiecutter.project_slug}}/docs/sentry.md
+++ b/{{cookiecutter.project_slug}}/docs/sentry.md
@@ -46,6 +46,6 @@ By default this is in the base config. Make sure the following is to your prefer
     )
 ```
 
-Update `k8s/base/django.configmap.yaml` `SENTRY_DSN_BACKEND`, `VITE_SENTRY_DSN_FRONTEND` with the DSNs provided for the relevant Sentry projects. 
+Update `k8s/base/app.configmap.yaml` `SENTRY_DSN_BACKEND`, `VITE_SENTRY_DSN_FRONTEND` with the DSNs provided for the relevant Sentry projects. 
 
 You can find them in Sentry by clicking Settings on the sidebar, then Projects on the secondary sidebar, then the project, then Client Keys (DSN)

--- a/{{cookiecutter.project_slug}}/frontend/src/main.tsx
+++ b/{{cookiecutter.project_slug}}/frontend/src/main.tsx
@@ -10,9 +10,9 @@ import { BrowserTracing } from "@sentry/tracing";
 {% endif %}
 
 {% if cookiecutter.use_sentry == 'y' %}
-const sentry_dsn = `https://${import.meta.env?.VITE_SENTRY_DSN_FRONTEND}`;
+const sentry_dsn = import.meta.env?.VITE_SENTRY_DSN_FRONTEND;
 Sentry.init({
-  dsn: import.meta.env?.VITE_SENTRY_DSN_FRONTEND ? sentry_dsn : '',
+  dsn: sentry_dsn ? sentry_dsn : '',
   environment: import.meta.env?.VITE_ENVIRONMENT ? import.meta.env?.VITE_ENVIRONMENT : 'production',
   release: import.meta.env?.VITE_RELEASE ? import.meta.env?.VITE_RELEASE : 'dev',
   integrations: [new BrowserTracing()],

--- a/{{cookiecutter.project_slug}}/frontend/src/main.tsx
+++ b/{{cookiecutter.project_slug}}/frontend/src/main.tsx
@@ -10,10 +10,11 @@ import { BrowserTracing } from "@sentry/tracing";
 {% endif %}
 
 {% if cookiecutter.use_sentry == 'y' %}
+const sentry_dsn = `https://${import.meta.env?.VITE_SENTRY_DSN_FRONTEND}`;
 Sentry.init({
-  dsn: `https://${process.env.SENTRY_DSN_FRONTEND}`,
-  environment: `${process.env.ENVIRONMENT}`,
-  release: `${process.env.RELEASE}`,
+  dsn: import.meta.env?.VITE_SENTRY_DSN_FRONTEND ? sentry_dsn : '',
+  environment: import.meta.env?.VITE_ENVIRONMENT ? import.meta.env?.VITE_ENVIRONMENT : 'production',
+  release: import.meta.env?.VITE_RELEASE ? import.meta.env?.VITE_RELEASE : 'dev',
   integrations: [new BrowserTracing()],
   tracesSampleRate: 1.0
 });

--- a/{{cookiecutter.project_slug}}/k8s/base/app.configmap.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/app.configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: django-config
+  name: app-config
 data:
   DJANGO_DEBUG: "False"
   USE_DOCKER: "yes"

--- a/{{cookiecutter.project_slug}}/k8s/base/celery.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/celery.yaml
@@ -23,16 +23,16 @@ spec:
           command: ["celery", "-A", "{{ cookiecutter.project_slug }}", "worker", "-E", "-l", "info"]
           envFrom:
             - configMapRef:
-                name: django-config
+                name: app-config
         - name: celerybeat
           image: {{ cookiecutter.project_slug }}_local_django:latest
           command: ["celery", "-A", "{{ cookiecutter.project_slug }}", "beat"]
           envFrom:
             - configMapRef:
-                name: django-config
+                name: app-config
         - name: flower
           image: {{ cookiecutter.project_slug }}_local_django:latest
           command: ["celery", "-A", "{{ cookiecutter.project_slug }}", "flower"]
           envFrom:
             - configMapRef:
-                name: django-config
+                name: app-config

--- a/{{cookiecutter.project_slug}}/k8s/base/django.configmap.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/django.configmap.yaml
@@ -30,4 +30,6 @@ data:
 {% if cookiecutter.use_sentry == 'y' %}
   SENTRY_DSN_BACKEND: ""
   ENVIRONMENT: "dev"
+  VITE_SENTRY_DSN_FRONTEND: ""
+  VITE_ENVIRONMENT: "dev"
 {% endif %}

--- a/{{cookiecutter.project_slug}}/k8s/base/django.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/django.yaml
@@ -42,7 +42,7 @@ spec:
               containerPort: 8000
           envFrom:
             - configMapRef:
-                name: django-config
+                name: app-config
             - secretRef:
                 name: secrets-config
       initContainers:
@@ -59,6 +59,6 @@ spec:
           command: ["python", "manage.py", "migrate"]
           envFrom:
             - configMapRef:
-                name: django-config
+                name: app-config
             - secretRef:
                 name: secrets-config

--- a/{{cookiecutter.project_slug}}/k8s/base/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
 {%- if cookiecutter.use_celery == "y" %}- ./celery.yaml{%- endif %}
-- ./django.configmap.yaml
+- ./app.configmap.yaml
 - ./django.yaml
 - ./mailhog.yaml
 - ./react.yaml

--- a/{{cookiecutter.project_slug}}/k8s/base/postgres.cnpg.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/postgres.cnpg.yaml
@@ -11,7 +11,7 @@ spec:
 
   envFrom:
   - configMapRef:
-      name: django-config
+      name: app-config
 
   primaryUpdateStrategy: unsupervised
 

--- a/{{cookiecutter.project_slug}}/k8s/base/postgres.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/postgres.yaml
@@ -42,7 +42,7 @@ spec:
             - containerPort: 5432
           envFrom:
           - configMapRef:
-              name: django-config
+              name: app-config
           - secretRef:
               name: secrets-config
           volumeMounts:

--- a/{{cookiecutter.project_slug}}/k8s/base/postgres.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/postgres.yaml
@@ -43,6 +43,8 @@ spec:
           envFrom:
           - configMapRef:
               name: django-config
+          - secretRef:
+              name: secrets-config
           volumeMounts:
             - name: postgres-volume-mount
               mountPath: /var/lib/postgresql/data

--- a/{{cookiecutter.project_slug}}/k8s/base/react.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/react.yaml
@@ -48,6 +48,6 @@ spec:
               value: django:8000
           envFrom:
             - configMapRef:
-                name: django-config
+                name: app-config
             - secretRef:
                 name: secrets-config

--- a/{{cookiecutter.project_slug}}/k8s/local/postgres.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/local/postgres.yaml
@@ -42,7 +42,7 @@ spec:
             - containerPort: 5432
           envFrom:
           - configMapRef:
-              name: django-config
+              name: app-config
           - secretRef:
               name: secrets-config
           volumeMounts:

--- a/{{cookiecutter.project_slug}}/k8s/local/postgres.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/local/postgres.yaml
@@ -43,6 +43,8 @@ spec:
           envFrom:
           - configMapRef:
               name: django-config
+          - secretRef:
+              name: secrets-config
           volumeMounts:
             - name: postgres-volume-mount
               mountPath: /var/lib/postgresql/data

--- a/{{cookiecutter.project_slug}}/k8s/prod/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/prod/kustomization.yaml
@@ -25,7 +25,7 @@ patches:
     name: mailhog
 
 configMapGenerator:
-  - name: django-config
+  - name: app-config
     behavior: merge
     literals:
      - ENVIRONMENT="production"

--- a/{{cookiecutter.project_slug}}/k8s/sandbox/kustomization.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/sandbox/kustomization.yaml
@@ -9,7 +9,7 @@ patches:
  - path: patches.yaml
 
 configMapGenerator:
-  - name: django-config
+  - name: app-config
     behavior: merge
     literals:
      - ENVIRONMENT="sandbox"


### PR DESCRIPTION
Also updated docs for the new local stack.
Seems like `.envrc` and `frontend/.env` / `frontend/src/.env.example` and documentation mentioning those could be removed. 