### PR TITLE
(feat) enable testing in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -381,3 +381,5 @@ dist
 *.tfstate.*
 *.tfvars
 *.tfvars.json
+
+.idea/

--- a/{{cookiecutter.project_slug}}/backend/Dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/Dockerfile
@@ -56,7 +56,7 @@ RUN set -x \
         -r /tmp/requirements/base.txt
 
 RUN set -x \
-    && if [ "$TEST" = "yes" ]; then pip --no-cache-dir --disable-pip-version-check install --no-deps \
+    && if [ "$TEST" = "yes" ] || [ "$DEVEL" = "yes" ]; then pip --no-cache-dir --disable-pip-version-check install --no-deps \
         -r /tmp/requirements/tests.txt; fi
 
 # Now we can build the application image


### PR DESCRIPTION
I needed to be able to run pytest locally. Currently TDD on scaf project is broken because the Dockerfile skips the tests requirements file in development. It was an easy fix that I already implemented on my becks project. 

I also added `.idea/` to gitignore 

