### PR TITLE
feat: use dynamic volume provisioning for postgres pvc

### DIFF
--- a/{{cookiecutter.project_slug}}/k8s/local/postgres.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/local/postgres.yaml
@@ -63,31 +63,14 @@ spec:
             claimName: postgres-pvc
 ---
 apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: postgres-pv
-  labels:
-    type: local
-spec:
-  storageClassName: manual
-  capacity:
-    storage: 1Gi
-  accessModes:
-    - ReadWriteOnce
-  hostPath:
-    path: /mnt/postgres-data
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: postgres-pvc
   labels:
     type: local
 spec:
-  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 500Mi
-  volumeName: postgres-pv


### PR DESCRIPTION
PR to use dynamic volume provisioning for the Postres PVC. We shouldn't hardcode the storage class or the mount path. We should defer this to the cluster configuration.

https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/#using-dynamic-provisioning