### PR TITLE
fix: keep postgres pvc across tilt restarts

### DIFF
--- a/{{cookiecutter.project_slug}}/k8s/local/postgres.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/local/postgres.yaml
@@ -65,6 +65,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    tilt.dev/down-policy: keep
   name: postgres-pvc
   labels:
     type: local


### PR DESCRIPTION
PR to ensure that the Postgres PV keeps its data across Tilt restarts