### PR TITLE
docs: use repo_url variable for git clone example

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -16,7 +16,7 @@ Consult the links below if you prefer to use Minikube or Docker Desktop instead:
 
 1. Get the repository
 
-       $ git clone git@github.com:Love-My-Delta-Inc/{{ cookiecutter.project_slug }}.git
+       $ git clone {{ cookiecutter.repo_url }}
        $ cd {{ cookiecutter.project_slug }}
 
 2. Prepare the environment variables. Edit the `.envrc` file to work for your environment.


### PR DESCRIPTION
We have a `repo_url` variable already in the cookie-cutter config so we might as well use it in the docs for the git clone command.