### PR TITLE
feat: upgrade django and python to latest stable versions

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -62,7 +62,7 @@ pipdeptree: ## Show the dependencies of installed packages as a tree structure
 	$(KUBECTL_EXEC_BACKEND) -c "pipdeptree"
 
 compile: backend/requirements/base.in backend/requirements/tests.in ## compile latest requirements to be built into the docker image
-	@docker run --rm -v $(shell pwd)/backend/requirements:/local python:3.10-slim-bullseye /bin/bash -c \
+	@docker run --rm -v $(shell pwd)/backend/requirements:/local python:3.12-slim-bullseye /bin/bash -c \
 		"apt-get update; apt-get install -y libpq-dev; \
 		 pip install pip-tools; \
 		 touch /local/base.txt; touch /local/production.txt; touch /local/tests.txt; touch /local/local.txt; \

--- a/{{cookiecutter.project_slug}}/Tiltfile
+++ b/{{cookiecutter.project_slug}}/Tiltfile
@@ -14,6 +14,7 @@ docker_build(
     context="backend",
     build_args={"DEVEL": "yes", "TEST": "yes"},
     live_update=[
+        sync("./backend/config", "/app/src/config"),
         sync("./backend/{{ cookiecutter.project_slug }}", "/app/src/{{ cookiecutter.project_slug }}"),
     ],
 )

--- a/{{cookiecutter.project_slug}}/backend/Dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build all of the dependencies then we will build the actual application image
-FROM python:3.10-slim-bullseye as build
+FROM python:3.12-slim-bullseye as build
 
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1
@@ -9,16 +9,16 @@ ARG DEVEL=no
 ARG TEST=no
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y \
+    && apt-get install --no-install-recommends -y \
     build-essential \
     ca-certificates \
     curl \
     gettext \
     gnupg \
-  && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-  && apt-get update \
-  && apt-get install --no-install-recommends -y \
+    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
     libffi-dev \
     libpq-dev \
     libssl-dev \
@@ -52,15 +52,15 @@ RUN set -x \
 
 RUN set -x \
     && pip --no-cache-dir --disable-pip-version-check install --no-deps \
-        -r /tmp/requirements/production.txt \
-        -r /tmp/requirements/base.txt
+    -r /tmp/requirements/production.txt \
+    -r /tmp/requirements/base.txt
 
 RUN set -x \
     && if [ "$TEST" = "yes" ]; then pip --no-cache-dir --disable-pip-version-check install --no-deps \
-        -r /tmp/requirements/tests.txt; fi
+    -r /tmp/requirements/tests.txt; fi
 
 # Now we can build the application image
-FROM python:3.10-slim-bullseye
+FROM python:3.12-slim-bullseye
 
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /app
@@ -80,27 +80,27 @@ RUN set -x \
     && mkdir -p /usr/share/man/man7
 
 RUN apt-get update \
-  # psycopg2 dependencies
-  && apt-get install --no-install-recommends -y \
+    # psycopg2 dependencies
+    && apt-get install --no-install-recommends -y \
     ca-certificates \
     curl \
     gettext \
     gnupg \
-  && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-  && apt-get update \
-  && apt-get install --no-install-recommends -y \
+    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
     libpq5 \
     $(if [ "$DEVEL" = "yes" ]; then echo 'bash postgresql-client-14'; fi) \
-  # awscli
-  && apt-get install -y \
+    # awscli
+    && apt-get install -y \
     awscli \
-  # cleaning up unused files
-  && apt-get remove -y \
+    # cleaning up unused files
+    && apt-get remove -y \
     curl \
     gnupg \
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN adduser --system --no-create-home django
 COPY --chown=django:django --from=build /app/ /app/

--- a/{{cookiecutter.project_slug}}/backend/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/backend/config/settings/base.py
@@ -4,8 +4,10 @@ Base settings to build other settings files upon.
 from pathlib import Path
 
 import environ
+
 {% if cookiecutter.use_sentry == 'y' %}
 import sentry_sdk
+
 {% endif %}
 
 ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
@@ -69,6 +71,7 @@ DJANGO_APPS = [
 ]
 THIRD_PARTY_APPS = [
     "crispy_forms",
+    "crispy_bootstrap5",
     "allauth",
     "allauth.account",
     "allauth.socialaccount",
@@ -137,6 +140,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#middleware
 MIDDLEWARE = [
+    "allauth.account.middleware.AccountMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "{{ cookiecutter.project_slug }}.utils.healthcheck.HealthCheckMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -209,7 +213,9 @@ TEMPLATES = [
 FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 # http://django-crispy-forms.readthedocs.io/en/latest/install.html#template-packs
-CRISPY_TEMPLATE_PACK = "bootstrap4"
+CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
+
+CRISPY_TEMPLATE_PACK = "bootstrap5"
 
 # FIXTURES
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/backend/requirements/base.in
+++ b/{{cookiecutter.project_slug}}/backend/requirements/base.in
@@ -1,39 +1,39 @@
-argon2-cffi==21.3.0
-crispy-bootstrap5==0.7
-django~=4.1.0
-django-allauth==0.52.0
-django-crispy-forms==1.14.0
-django-environ==0.9.0
-django-model-utils==4.3.1
-django-redis==5.2.0
-Pillow==9.4.0
-# urllib3<1.27,>=1.25.4 (from botocore==1.29.133), see #60 
-urllib3<1.27
+argon2-cffi
+crispy-bootstrap5
+daphne
+django
+django-allauth
+django-crispy-forms
+django-environ
+django-model-utils
+django-redis
+Pillow
+urllib3
 {% if cookiecutter.use_sentry == 'y' %}
-sentry-sdk[django]==1.40.0
+sentry-sdk[django]
 {% endif %}
 
 {%- if cookiecutter.use_compressor == "y" %}
-django-compressor==4.1
+django-compressor
 {%- endif %}
 
 {%- if cookiecutter.use_celery == "y" %}
-celery~=5.2.0
-django-celery-beat==2.4.0
-flower==1.2.0
-redis~=4.4.0
+celery
+django-celery-beat
+flower
+redis
 {%- endif %}
 
 {%- if cookiecutter.use_drf == "y" %}
-django-cors-headers==3.13.0
-djangorestframework~=3.14.0
-drf-spectacular==0.25.1
+django-cors-headers
+djangorestframework
+drf-spectacular
 {%- endif %}
 
 {%- if cookiecutter.use_graphql == "y" %}
-strawberry-graphql-django==0.46.1
+strawberry-graphql-django
 {%- endif %}
 
 {%- if cookiecutter.use_graphql == "y" or cookiecutter.use_drf == "y" %}
-django-cors-headers==3.13.0
+django-cors-headers
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/backend/requirements/local.in
+++ b/{{cookiecutter.project_slug}}/backend/requirements/local.in
@@ -1,9 +1,9 @@
 # Local development dependencies go here
 debugpy
-django-debug-toolbar~=3.2.0
-# django-extensions==3.2.0
+django-debug-toolbar
+django-extensions
 ipdb
 pip-tools
 pipdeptree
-pydevd-pycharm==241.18034.82
-Werkzeug>=2.0
+pydevd-pycharm
+Werkzeug

--- a/{{cookiecutter.project_slug}}/backend/requirements/production.in
+++ b/{{cookiecutter.project_slug}}/backend/requirements/production.in
@@ -2,19 +2,19 @@
 
 -r base.txt
 
-gunicorn==20.1.0  # https://github.com/benoitc/gunicorn
-psycopg2==2.9.3  # https://github.com/psycopg/psycopg2
+gunicorn
+psycopg2
 uvicorn[standard]
 
 # Django
 # ------------------------------------------------------------------------------
-django-storages[boto3]==1.14.2  # https://github.com/jschneier/django-storages
-daphne==4.0.0
+django-storages[boto3] # https://github.com/jschneier/django-storages
+daphne
 
 {%- if cookiecutter.mail_service == 'Mailgun' %}
-django-anymail[mailgun]==8.6  # https://github.com/anymail/django-anymail
+django-anymail[mailgun] # https://github.com/anymail/django-anymail
 {%- elif cookiecutter.mail_service == 'Amazon SES' %}
-django-anymail[amazon_ses]==8.6  # https://github.com/anymail/django-anymail
+django-anymail[amazon_ses] # https://github.com/anymail/django-anymail
 {%- elif cookiecutter.mail_service == 'Other SMTP' %}
-django-anymail==8.6  # https://github.com/anymail/django-anymail
+django-anymail # https://github.com/anymail/django-anymail
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/backend/requirements/tests.in
+++ b/{{cookiecutter.project_slug}}/backend/requirements/tests.in
@@ -1,12 +1,11 @@
 # Test dependencies go here.
 -r base.txt
 
-coverage==6.4.4
-flake8==5.0.4 # pyup: != 2.6.0
-django-test-plus==2.2.0
-factory-boy==3.2.1
-django-coverage-plugin==2.0.3
-daphne==4.0.0
+coverage
+flake8
+django-test-plus
+factory-boy
+django-coverage-plugin
 
 # pytest
 pytest-django

--- a/{{cookiecutter.project_slug}}/bitbucket-pipelines.yml
+++ b/{{cookiecutter.project_slug}}/bitbucket-pipelines.yml
@@ -1,4 +1,4 @@
-image: python:3.10
+image: python:3.12
 
 definitions:
   services:


### PR DESCRIPTION
This PR upgrades the Scaf template to the latest stable Django and Python versions.

Most importantly, I removed the pins in the *.in files to ensure that a newly generated project always has the latest Django version. This is not a cause for concern since running `make compile` after project creation will immediately pin all package versions. Additionally, this forces us to perform regular tests of Scaf-generated projects with the latest versions.

I tested the changes in the PR by creating a new project and verifying that both the frontend and backend sites work and that NextJS can make GraphQL queries against Django.