### PR TITLE
feat: improve installation script to handle preferred bin folder

### DIFF
--- a/.github/workflows/setup-project.yaml
+++ b/.github/workflows/setup-project.yaml
@@ -47,5 +47,5 @@ jobs:
         git config --global init.defaultBranch main
         git config --global user.email "setup-project--create@example.com"
         git config --global user.name "CI CD Setup Project"
-        /usr/local/bin/scaf myproject --no-input
+        $HOME/.local/bin/scaf myproject --no-input
 

--- a/.github/workflows/setup-project.yaml
+++ b/.github/workflows/setup-project.yaml
@@ -41,5 +41,5 @@ jobs:
       run: |
         IMAGE_TAG=$GITHUB_SHA
         echo "Running scaf with sixfeetup/scaf:$IMAGE_TAG"
-        /usr/local/bin/scaf myproject --no-input
+        $HOME/.local/bin/scaf myproject --no-input
 

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,33 @@
-#!/bin/bash
+#!/bin/sh
+
 
 BRANCH=${SCAF_SCRIPT_BRANCH:-main}
 SCAF_SCRIPT_URL="https://raw.githubusercontent.com/sixfeetup/scaf/${BRANCH}/scaf"
 TEMP_DOWNLOAD="./scaf"
-DESTINATION="/usr/local/bin/scaf"
+PREFERRED_BIN_FOLDER=${PREFERRED_BIN_FOLDER:-"${HOME}/.local/bin"}
+DESTINATION="${PREFERRED_BIN_FOLDER}/scaf"
+
+
+ensure_bin_folder() {
+  if [ ! -d "$PREFERRED_BIN_FOLDER" ]; then
+      echo "Creating $PREFERRED_BIN_FOLDER..."
+      mkdir -p $PREFERRED_BIN_FOLDER
+  fi
+  if [ ! -w "$PREFERRED_BIN_FOLDER" ]; then
+      echo "You don't have write permission to $PREFERRED_BIN_FOLDER."
+      echo "Please run the script as a user who has write permission to $PREFERRED_BIN_FOLDER"
+      echo "Or set PREFERRED_BIN_FOLDER to a writable directory."
+      exit 1
+  fi
+  # verify if PREFERRED_BIN_FOLDER is in PATH or exit with advice.
+  if ! [ -n "$PATH" ] && [ -n "$HOME" ] && echo "$PATH" | grep -q ":$HOME/.local/bin:"; then
+      echo "Your PATH is missing $PREFERRED_BIN_FOLDER."
+      echo "Please add the following line to your shell profile file (e.g. ~/.bashrc, ~/.zshrc, etc.)"
+      echo "export PATH=\$PATH:$PREFERRED_BIN_FOLDER"
+      echo "Or you can set PREFERRED_BIN_FOLDER to a writable directory that is already in your PATH."
+      exit 1
+  fi
+}
 
 command_exists() {
     command -v "$1" > /dev/null 2>&1
@@ -28,7 +52,7 @@ detect_os_and_arch() {
                 *)      os_arch="darwin-unknown" ;;
             esac
             ;;
-        *)          
+        *)
             os_arch="unknown"
             ;;
     esac
@@ -46,7 +70,7 @@ install_kubectl() {
             url="https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${os}/${arch}/kubectl"
             curl -LO $url
             chmod +x ./kubectl
-            sudo mv ./kubectl /usr/local/bin/kubectl
+            sudo mv ./kubectl $PREFERRED_BIN_FOLDER/kubectl
             ;;
         *)
             echo "Unsupported OS or architecture: $os_arch"
@@ -64,7 +88,7 @@ install_kind() {
         "linux-amd64"|"darwin-amd64"|"darwin-arm64"|"linux-arm64")
         curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.11.1/kind-$os_arch"
         chmod +x ./kind
-        sudo mv ./kind /usr/local/bin/kind
+        sudo mv ./kind $PREFERRED_BIN_FOLDER/kind
         ;;
     *)
         echo "Unsupported OS or architecture: $os_arch"
@@ -101,6 +125,8 @@ install_scaf() {
     fi
 }
 
+# Start the installation process
+ensure_bin_folder
 for tool in kubectl kind tilt; do
     if ! command_exists $tool; then
         echo "$tool is not installed."


### PR DESCRIPTION
- change `/usr/local/bin/` installation directory to a variable `PREFERRED_BIN_FOLDER` that defaults to `${HOME}/.local/bin`
- check folder existence and create it if necessary in `ensure_bin_folder` function
- check write permissions to bin folder and exit with warning if not writable
- validate if bin folder is in PATH, else exit with suggestion to add it
- ensure `kubectl`, `kind` and `scaf` tools are moved to the preferred bin folder
- make function `ensure_bin_folder` as first step at installation process.