### PR TITLE
feat: add automatic git remote configuration

### DIFF
--- a/.github/workflows/setup-project.yaml
+++ b/.github/workflows/setup-project.yaml
@@ -37,6 +37,7 @@ jobs:
         git config --global user.email "setup-project--install@example.com"
         git config --global user.name "CI CD install deps"
         echo "Downloading install script from $INSTALL_URL"
+        rm -f $HOME/.local/bin/scaf
         curl -sSL $INSTALL_URL | sh
 
     - name: Create Project with Scaf

--- a/.github/workflows/setup-project.yaml
+++ b/.github/workflows/setup-project.yaml
@@ -48,5 +48,6 @@ jobs:
         git config --global init.defaultBranch main
         git config --global user.email "setup-project--create@example.com"
         git config --global user.name "CI CD Setup Project"
-        $HOME/.local/bin/scaf myproject --no-input
-
+        
+        REPO_URL="https://github.com/sixfeetup/scaf/tree/$GITHUB_REF_NAME"
+        $HOME/.local/bin/scaf myproject --no-input $REPO_URL

--- a/.github/workflows/setup-project.yaml
+++ b/.github/workflows/setup-project.yaml
@@ -49,5 +49,5 @@ jobs:
         git config --global user.email "setup-project--create@example.com"
         git config --global user.name "CI CD Setup Project"
         
-        REPO_URL="https://github.com/sixfeetup/scaf/tree/$GITHUB_REF_NAME"
-        $HOME/.local/bin/scaf myproject --no-input $REPO_URL
+        REPO_URL="https://github.com/sixfeetup/scaf.git"
+        $HOME/.local/bin/scaf myproject --no-input --checkout $GITHUB_REF_NAME $REPO_URL

--- a/README.md
+++ b/README.md
@@ -109,3 +109,47 @@ When making changes to scaf, keep the following in mind:
 - update pins in requirements/*.in files but *don't\* commit the compiled requirements.txt
   files to the repo.
 - update to the latest Python supported by Django. For Django 4.1, this is 3.8, 3.9, and 3.10.
+
+### Testing
+To test the cookiecutter portion of scaf, create virtual environment ad install black, isort and cookiecutter.
+Create a test cookiecutter.yaml file with the following content:
+```yaml
+---
+default_context:
+  author_name: Joe Sixie
+  aws_account_id: "000000000000"
+  aws_region: us-east-1
+  create_nextjs_frontend: y
+  debug: n
+  description: Behold My Awesome Project!
+  domain_name: sixfeetup.com
+  email: joe-sixie@sixfeetup.com
+  mail_service: Mailgun
+  project_dash: my-awesome-sixie-project
+  project_name: My Awesome Sixie Project
+  project_slug: my_awesome_sixie_project
+  repo_name: my_awesome_sixie_project
+  repo_url: git@github.com:sixfeetup/my_awesome_sixie_project.git
+  source_control_organization_slug: sixfeetup
+  source_control_provider: github.com
+  timezone: US/Eastern
+  use_celery: n
+  use_graphql: y
+  use_sentry: n
+  version: 0.1.0
+
+```
+
+Then create a helper script to run the tests:
+```bash
+#! /bin/bash
+
+SCAF_ROOT=/Users/gfranxman/sfu/ScafDev/scaf
+OUTPUT_FOLDER=./scaf-test
+TEST_CONFIG=./scaf-cookiecutter.yaml
+
+rm -rf $OUTPUT_FOLDER && cookiecutter $SCAF_ROOT --no-input --config-file $TEST_CONFIG -o $OUTPUT_FOLDER -v
+
+```
+
+Run the script and check the output folder for the generated project.

--- a/README.md
+++ b/README.md
@@ -153,3 +153,22 @@ rm -rf $OUTPUT_FOLDER && cookiecutter $SCAF_ROOT --no-input --config-file $TEST_
 ```
 
 Run the script and check the output folder for the generated project.
+
+To test run the project using your branch for scaf and the cookiecutter you have to tell it
+which branch and repo to use. Here is an example script to do that: 
+
+(You will need to adjust the paths and branch name to match your setup):
+```bash
+#! /bin/bash
+
+SCAF_ROOT=/Users/gfranxman/sfu/ScafDev/scaf
+OUTPUT_FOLDER=./scaf-test
+TEST_CONFIG=./scaf-cookiecutter.yaml
+
+BRANCH_NAME=gfranxman/configure-git-remote
+BASE_REPO=https://github.com/sixfeetup/scaf.git
+
+
+rm -rf $OUTPUT_FOLDER && \
+$SCAF_ROOT/scaf myproject --no-input --checkout $BRANCH_NAME ${BASE_REPO} 
+```

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -294,7 +294,7 @@ def main():
     init_git_repo()
     configure_git_remote()
 
-    print(SUCCESS + "Project initialized, keep up the good work!" + TERMINATOR)
+    print(SUCCESS + "Project initialized, keep up the good work!!" + TERMINATOR)
 
 
 if __name__ == "__main__":

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -241,15 +241,27 @@ def remove_graphql_files():
         )
     )
 
+
+def init_git_repo():
+    print(INFO + "Initializing git repository..." + TERMINATOR)
+    print(INFO + f"Current working directory: {os.getcwd()}" + TERMINATOR)
+    subprocess.run(shlex.split("git init ."))
+    print(SUCCESS + "Git repository initialized." + TERMINATOR)
+
+
 def configure_git_remote():
     repo_url = "{{ cookiecutter.repo_url }}"
     if repo_url:
         print(INFO + f"repo_url: {repo_url}" + TERMINATOR)
-        print(INFO + f"Current working directory: {os.getcwd()}" + TERMINATOR)
-        subprocess.run(shlex.split("git init ."))
         command = f"git remote add origin {repo_url}"
         subprocess.run(shlex.split(command))
         print(SUCCESS + f"Remote origin={repo_url} added." + TERMINATOR)
+    else:
+        print(
+            WARNING
+            + "No repo_url provided. Skipping git remote configuration."
+            + TERMINATOR
+        )
 
 
 def main():
@@ -279,6 +291,7 @@ def main():
     subprocess.run(shlex.split("black ./backend"))
     subprocess.run(shlex.split("isort --profile=black ./backend"))
 
+    init_git_repo()
     configure_git_remote()
 
     print(SUCCESS + "Project initialized, keep up the good work!" + TERMINATOR)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -241,6 +241,16 @@ def remove_graphql_files():
         )
     )
 
+def configure_git_remote():
+    repo_url = "{{ cookiecutter.repo_url }}"
+    if repo_url:
+        print(INFO + f"repo_url: {repo_url}" + TERMINATOR)
+        print(INFO + f"Current working directory: {os.getcwd()}" + TERMINATOR)
+        subprocess.run(shlex.split("git init ."))
+        command = f"git remote add origin {repo_url}"
+        subprocess.run(shlex.split(command))
+        print(SUCCESS + f"Remote origin={repo_url} added." + TERMINATOR)
+
 
 def main():
     debug = "{{ cookiecutter.debug }}".lower() == "y"
@@ -268,6 +278,8 @@ def main():
 
     subprocess.run(shlex.split("black ./backend"))
     subprocess.run(shlex.split("isort --profile=black ./backend"))
+
+    configure_git_remote()
 
     print(SUCCESS + "Project initialized, keep up the good work!" + TERMINATOR)
 

--- a/install.sh
+++ b/install.sh
@@ -235,6 +235,7 @@ install_scaf() {
 }
 
 # Start the installation process
+echo "Installing scaf from $SCAF_SCRIPT_URL for the $BRANCH branch..."
 ensure_bin_folder
 check_top_level_dependencies
 check_git_config

--- a/scaf
+++ b/scaf
@@ -63,7 +63,6 @@ if [ $? -eq 0 ]; then
     kind create cluster --name $PROJECT_SLUG
     cd $PROJECT_SLUG
     make compile
-    git init .
     git add .
     git commit -m "Initial commit"
 else

--- a/scaf
+++ b/scaf
@@ -63,6 +63,9 @@ if [ $? -eq 0 ]; then
     kind create cluster --name $PROJECT_SLUG
     cd $PROJECT_SLUG
     make compile
+    echo "Dependencies compiled successfully."
+    pwd
+    echo "Performing initial commit."
     git add .
     git commit -m "Initial commit"
 else


### PR DESCRIPTION
Added functionality to automatically configure git remote repositories to the scaf creation process.

This is done in the post_gen_project.py hook file using a new function called `configure_git_remote()`.  This function takes the repository URL built during the cookiecutter build out and initializes a new git repository in the new project directory.  It then sets the entered URL as the 'origin' remote.

Subsequently, removed the `git init .` statement from the scaf script since it now occurs in the `configure_git_remote()` function of the post_gen_project hook.

Also provided a detailed guide in README.md on how to test the cookiecutter portion of scaf.