### PR TITLE
feat(install.sh): force re-download of Scaf on each install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -214,6 +214,10 @@ install_tilt() {
 }
 
 install_scaf() {
+    # Install/re-install scaf
+    if [ -f "$TEMP_DOWNLOAD" ]; then
+        rm $TEMP_DOWNLOAD
+    fi
     # Download and install scaf
     echo "Downloading scaf from $SCAF_SCRIPT_URL..."
     curl -L $SCAF_SCRIPT_URL -o $TEMP_DOWNLOAD
@@ -248,8 +252,4 @@ for tool in kubectl kind tilt; do
     fi
 done
 
-if ! command_exists scaf; then
-    install_scaf
-else
-    echo "scaf is already installed."
-fi
+install_scaf


### PR DESCRIPTION
In the script, before the step to download and install 'scaf', a check if a file at the 'TEMP_DOWNLOAD' location exists.
If such a file does exist, it is removed before proceeding with the installation.