### PR TITLE
feat: implement s3 storage for static and media files on production

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/backend/config/settings/production.py
@@ -81,12 +81,12 @@ AWS_S3_REGION_NAME = env("DJANGO_AWS_REGION_NAME", default="us-east-1")
 
 # STATIC
 # ------------------------
-STATICFILES_STORAGE = "{{ cookiecutter.project_slug }}.utils.storages.StaticStorage"
+STATICFILES_STORAGE = "{{ cookiecutter.project_slug }}.utils.cloud_storage.S3StaticStorage"
 STATIC_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/static/"
 
 # MEDIA
 # ------------------------------------------------------------------------------
-DEFAULT_FILE_STORAGE = "{{ cookiecutter.project_slug }}.utils.storages.MediaStorage"
+DEFAULT_FILE_STORAGE = "{{ cookiecutter.project_slug }}.utils.cloud_storage.S3MediaStorage"
 MEDIA_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com/media/"
 
 # TEMPLATES

--- a/{{cookiecutter.project_slug}}/backend/{{cookiecutter.project_slug}}/utils/cloud_storage.py
+++ b/{{cookiecutter.project_slug}}/backend/{{cookiecutter.project_slug}}/utils/cloud_storage.py
@@ -1,10 +1,10 @@
 from storages.backends.s3boto3 import S3Boto3Storage
 
 
-class StaticStorage(S3Boto3Storage):
+class S3StaticStorage(S3Boto3Storage):
     location = "static"
 
 
-class MediaStorage(S3Boto3Storage):
+class S3MediaStorage(S3Boto3Storage):
     location = "media"
     file_overwrite = False


### PR DESCRIPTION
- Changed DEFAULT_FILE_STORAGE and STATICFILES_STORAGE from local to S3 in production settings.
- Renamed utility 'storages.py' to 'cloud_storage.py'.
- Renamed classes in storage utility to reflect usage of S3 - 'StaticStorage' to 'S3StaticStorage' and 'MediaStorage' to 'S3MediaStorage'.

This was done primarily for clarity and to avoid name conflicts over the storages package.