### PR TITLE
feat: add party_popper function to enhance project initiation experience

### DIFF
--- a/scaf
+++ b/scaf
@@ -44,6 +44,21 @@ if [[ "$COOKIECUTTER_OPTIONS" != *"--no-input"* ]]; then
   DOCKER_RUN_OPTIONS="-it"
 fi
 
+party_popper() {
+    for i in {1..4}; do
+        echo -ne "\r🎉 POP! 💥"
+        sleep 0.3
+        echo -ne "\r💥 POP! 🎉"
+        sleep 0.3
+    done
+    echo -e "\r🎊 Congrats! Your $PROJECT_SLUG project is ready! 🎉"
+    echo
+    echo "To get started, run:"
+    echo "cd $PROJECT_SLUG"
+    echo "tilt up"
+    echo
+}
+
 echo "DOCKER_RUN_OPTIONS: $DOCKER_RUN_OPTIONS"
 echo "COOKIECUTTER_OPTIONS: $COOKIECUTTER_OPTIONS"
 echo "REPO_URL: $REPO_URL"
@@ -66,7 +81,10 @@ if [ $? -eq 0 ]; then
     git init .
     git add .
     git commit -m "Initial commit"
+    echo
+    party_popper
 else
     echo "Failed to create project."
     exit 1
 fi
+


### PR DESCRIPTION
- This function celebrates successful project creation by simulating a 'party popper' animation.
- It also provides brief instructions on how to get started with the new project.
- This makes the user experience more interactive and enjoyable.
- The function is invoked after project creation and initial commit.
- Critical when the COOKIECUTTER process fails - user is still informed about the failure. Is there a sad-trombone emoji?