### PR TITLE
chore: update Dockerfiles and Makefile to use 'uv' for pip commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-alpine
 
 RUN apk add git shadow su-exec && \
-  pip install uv \
+  pip install uv && \
   uv pip install black isort cookiecutter
 
 COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.10-alpine
 
-RUN apk add git shadow su-exec && \
-  pip install uv && \
-  uv pip install black isort cookiecutter
+RUN set -eux; \
+  apk add git shadow su-exec; \
+  PIP_ROOT_USER_ACTION=ignore pip install uv; \
+  uv pip install --system black isort cookiecutter
 
 COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.10-alpine
 
 RUN apk add git shadow su-exec && \
-  pip install --upgrade pip && \
-  pip install black isort cookiecutter
+  pip install uv \
+  uv pip install black isort cookiecutter
 
 COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -26,7 +26,7 @@ check-lint-and-test-frontend:  ## Frontend Lint & Typecheck & Test
 backend-test: ## Execute backend tests
 ifeq ($(CI),true)
 	cd backend; \
-	pip install \
+	uv pip install \
 		-r requirements/production.txt \
 		-r requirements/tests.txt; \
 	cd {{ cookiecutter.project_slug }}; \
@@ -60,17 +60,17 @@ outdated: ## Show all the outdated packages with their latest versions in the co
 	$(KUBECTL_EXEC_BACKEND) -c "pip list --outdated"
 
 pipdeptree: ## Show the dependencies of installed packages as a tree structure
-	$(KUBECTL_EXEC_BACKEND) -c "pipdeptree"
+	$(KUBECTL_EXEC_BACKEND) -c "uv pip tree --no-cache"
 
 compile: backend/requirements/base.in backend/requirements/tests.in ## compile latest requirements to be built into the docker image
 	@docker run --rm -v $(shell pwd)/backend/requirements:/local python:3.12-slim /bin/bash -c \
 		"apt-get update; apt-get install -y libpq-dev; \
-		 PIP_ROOT_USER_ACTION=ignore pip install --disable-pip-version-check pip-tools; \
+		 pip install uv; \
 		 touch /local/base.txt; touch /local/production.txt; touch /local/tests.txt; touch /local/local.txt; \
-		 python -m piptools compile --upgrade --allow-unsafe --generate-hashes --output-file /local/base.txt /local/base.in; \
-		 python -m piptools compile --upgrade --allow-unsafe --generate-hashes --output-file /local/production.txt /local/production.in; \
-		 python -m piptools compile --upgrade --allow-unsafe --generate-hashes --output-file /local/tests.txt /local/tests.in; \
-		 python -m piptools compile --upgrade --allow-unsafe --output-file /local/local.txt /local/local.in"
+		 uv pip compile --upgrade --generate-hashes --output-file /local/base.txt /local/base.in; \
+		 uv pip compile --upgrade --generate-hashes --output-file /local/production.txt /local/production.in; \
+		 uv pip compile --upgrade --generate-hashes --output-file /local/tests.txt /local/tests.in; \
+		 uv pip compile --upgrade --output-file /local/local.txt /local/local.in"
 
 shell-backend:  ## Shell into the running Django container
 	$(KUBECTL_EXEC_BACKEND)

--- a/{{cookiecutter.project_slug}}/backend/Dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/Dockerfile
@@ -37,23 +37,21 @@ ENV PATH="/app/bin:${PATH}"
 
 # Next, we want to update pip, setuptools, and wheel inside of this virtual
 # environment to ensure that we have the latest versions of them.
-RUN pip --no-cache-dir --disable-pip-version-check install --upgrade pip setuptools wheel
+RUN pip --no-cache-dir install --upgrade uv
+RUN uv pip --no-cache install --upgrade setuptools wheel
 
 COPY requirements /tmp/requirements
 
 RUN set -x \
-    && if [ "$DEVEL" = "yes" ]; then pip --no-cache-dir --disable-pip-version-check install --upgrade pip-tools; fi
+    && if [ "$DEVEL" = "yes" ]; then uv pip --no-cache install -r /tmp/requirements/local.txt; fi
 
 RUN set -x \
-    && if [ "$DEVEL" = "yes" ]; then pip --no-cache-dir --disable-pip-version-check install -r /tmp/requirements/local.txt; fi
-
-RUN set -x \
-    && pip --no-cache-dir --disable-pip-version-check install --no-deps \
+    && uv pip --no-cache install --no-deps \
     -r /tmp/requirements/production.txt \
     -r /tmp/requirements/base.txt
 
 RUN set -x \
-    && if [ "$TEST" = "yes" ]; then pip --no-cache-dir --disable-pip-version-check install --no-deps \
+    && if [ "$TEST" = "yes" ]; then uv pip --no-cache install --no-deps \
     -r /tmp/requirements/tests.txt; fi
 
 # Now we can build the application image

--- a/{{cookiecutter.project_slug}}/backend/requirements/local.in
+++ b/{{cookiecutter.project_slug}}/backend/requirements/local.in
@@ -3,7 +3,5 @@ debugpy
 django-debug-toolbar
 django-extensions
 ipdb
-pip-tools
-pipdeptree
 pydevd-pycharm~=233.13135.95
 Werkzeug


### PR DESCRIPTION
- Updated main Dockerfile to replace pip commands with uv pip.
- Modified backend Dockerfile to install uv and use it for managing pip packages.
- Adjusted Makefile to include uv for backend testing and package compilation.
- Removed pip-tools and pipdeptree from local requirements as part of the cleanup.
- implements #346 