### PR TITLE
feat: reorder environment variables in k8s django config

### DIFF
--- a/{{cookiecutter.project_slug}}/k8s/base/django.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/django.yaml
@@ -36,10 +36,10 @@ spec:
             - name: http-server
               containerPort: 8000
           envFrom:
-            - secretRef:
-                name: secrets-config
             - configMapRef:
                 name: app-config
+            - secretRef:
+                name: secrets-config
           livenessProbe:
             httpGet:
               path: /healthz

--- a/{{cookiecutter.project_slug}}/k8s/base/django.yaml
+++ b/{{cookiecutter.project_slug}}/k8s/base/django.yaml
@@ -76,7 +76,7 @@ spec:
           image: backend:latest
           command: ["python", "manage.py", "migrate"]
           envFrom:
-            - secretRef:
-                name: secrets-config
             - configMapRef:
                 name: app-config
+            - secretRef:
+                name: secrets-config


### PR DESCRIPTION
Rearranged the order in which the environment variables are loaded in the Kubernetes configuration file for Django.
Environment variables will now be loaded from 'app-config' ConfigMap first, followed by the 'secrets-config'.
This allows the local secrets config to override the app-config and not the other way around.