### PR TITLE
feat: update docker build-push-action to v5 and utilize github's

### DIFF
--- a/.github/workflows/setup-project.yaml
+++ b/.github/workflows/setup-project.yaml
@@ -9,6 +9,10 @@ jobs:
     steps:
     - name: Check out the repo
       uses: actions/checkout@v3
+      # not needed? https://github.com/docker/build-push-action/tree/releases/v5?tab=readme-ov-file#git-context
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Log in to Docker Hub
       uses: docker/login-action@v3

--- a/.github/workflows/setup-project.yaml
+++ b/.github/workflows/setup-project.yaml
@@ -16,11 +16,15 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
+    - name: Build and push Docker image using github's buildkit cache
+      uses: docker/build-push-action@v5
       with:
         push: true
         tags: sixfeetup/scaf:${{ github.sha }}
+        context: .
+        file: ./Dockerfile
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
   setup:
     environment: dev


### PR DESCRIPTION
buildkit cache

- Switched to Docker's build-push-action from version 2 to version 5 in the setup-project.yaml workflow file.
- Included context and file fields set to current directory and Dockerfile respectively.
- Added cache-from and cache-to fields with type=gha and mode=max to make use of GitHub's BuildKit cache for Docker builds.