### PR TITLE
ci: semantic release failure workaround

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -28,4 +28,6 @@ jobs:
       - name: Run Semantic Release
         run: npx semantic-release
         env:
+          CI_VERSION_WORKAROUND_APP_ID: ${{ vars.CI_VERSION_WORKAROUND_APP_ID }}
+          CI_VERSION_WORKAROUND_APP_PRIVATE_KEY: ${{ secrets.CI_VERSION_WORKAROUND_APP_PRIVATE_KEY }}
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -10,8 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     steps:
-      - uses: actions/checkout@v4
+      - name: Prepare workaround
+        # Create a GitHub App token to authenticate as the workaround app.
+        uses: actions/create-github-app-token@v1
+        id: app-token
         with:
+          app-id: ${{ vars.CI_VERSION_WORKAROUND_APP_ID }}
+          private-key: ${{ secrets.CI_VERSION_WORKAROUND_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        # Use the workaround app-token to pull all history and tags for the repository.
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -26,8 +38,12 @@ jobs:
         run: npm audit signatures
 
       - name: Run Semantic Release
+        # Use the workaround app-token to authenticate as the workaround app in order to
+        # push tags to the protected branch.
         run: npx semantic-release
         env:
-          CI_VERSION_WORKAROUND_APP_ID: ${{ vars.CI_VERSION_WORKAROUND_APP_ID }}
-          CI_VERSION_WORKAROUND_APP_PRIVATE_KEY: ${{ secrets.CI_VERSION_WORKAROUND_APP_PRIVATE_KEY }}
-          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+          # Deprecated in favor of the app token.
+          #CI_VERSION_WORKAROUND_APP_ID: ${{ vars.CI_VERSION_WORKAROUND_APP_ID }}
+          #CI_VERSION_WORKAROUND_APP_PRIVATE_KEY: ${{ secrets.CI_VERSION_WORKAROUND_APP_PRIVATE_KEY }}
+          #GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}  # I think this is deprecated in favor of the app token
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
These changes are intended to allow the ci semantic release process to push its tags and changes from bumping the version back into the protected branch (main).

Example of such failure: https://github.com/sixfeetup/scaf/actions/runs/10490831281/job/29058471741