### PR TITLE
ci: Fix GitHub action to build for amd and arm architectures and tag latest build with latest

### DIFF
--- a/.github/workflows/setup-project.yaml
+++ b/.github/workflows/setup-project.yaml
@@ -24,11 +24,14 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         push: true
-        tags: sixfeetup/scaf:${{ github.sha }}
+        tags: |
+          sixfeetup/scaf:${{ github.sha }}
+          sixfeetup/scaf:latest
         context: .
         file: ./Dockerfile
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        platforms: linux/amd64,linux/arm64
 
   setup:
     environment: dev


### PR DESCRIPTION
Related to #381

Update GitHub action to build and push Docker images for both amd and arm architectures, and tag the latest build with 'latest'.

* **Build and push Docker image**: Update the `docker/build-push-action` step to build for both amd and arm architectures.
* **Tagging**: Add a new tag `sixfeetup/scaf:latest` to the `tags` field in the `docker/build-push-action` step.
* **Platforms**: Ensure the `platforms` field includes both `linux/amd64` and `linux/arm64`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sixfeetup/scaf/issues/381?shareId=6cb64e80-01c6-4e78-b9e5-14e4952cbd75).