### PR TITLE
docs: add disk space warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ be found on your system.
 
 ## Creating a new project using this repo
 
+NB: Before you continue, make sure that you have at least 5 to 10 GB of free
+space available to Docker. Note that Docker Desktop on MacOS has its own
+resource limits separate from the host.
+
 Run `scaf myproject`, answer all the questions, and you'll have your new project!
 
 Inside `myproject/README.md`, you will have more


### PR DESCRIPTION
This PR adds a note to the README to warn users to check the disk space available to Docker before creating a new project. Checking the actual disk space available in a cross-platform manner is challenging. Figuring out whether one should check actual disk space or space available to Docker is even more complex.