### PR TITLE
feat: enable prometheus metrics retention for 90 days

### DIFF
--- a/{{cookiecutter.project_slug}}/argocd/base/kube-prometheus-stack/app.yaml
+++ b/{{cookiecutter.project_slug}}/argocd/base/kube-prometheus-stack/app.yaml
@@ -26,6 +26,22 @@ spec:
             requests:
               cpu: 50m
               memory: 100Mi
+        prometheus:
+          prometheusSpec:
+            podMonitorSelectorNilUsesHelmValues: false
+            podMonitorSelector: {}
+            # Add retention configuration for Prometheus
+            retention: 90d
+            retentionSize: 9GB
+            # Adjust storage size if needed
+            storageSpec:
+              volumeClaimTemplate:
+                spec:
+                  storageClassName: local-path
+                  accessModes: ["ReadWriteOnce"]
+                  resources:
+                    requests:
+                      storage: 10Gi
 
   destination:
     server: "https://kubernetes.default.svc"


### PR DESCRIPTION
This PR enables the retention of Prometheus metrics for ninety days. The default retention period is ten days. 