### PR TITLE
fix: updating tests in install.sh to detect missing preferred bin folder.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,8 +18,8 @@ ensure_bin_folder() {
       echo "Or set PREFERRED_BIN_FOLDER to a writable directory."
       exit 1
   fi
-  # verify if PREFERRED_BIN_FOLDER is in PATH or exit with advice.
-  if ! [ -n "$PATH" ] && [ -n "$HOME" ] && echo "$PATH" | grep -q ":$HOME/.local/bin:"; then
+
+  if [ -z "$PATH" ] || [ -z "$HOME" ] || ! echo $PATH | grep -qE ":?$PREFERRED_BIN_FOLDER:?"; then
       echo "Your PATH is missing $PREFERRED_BIN_FOLDER."
       echo "Please add the following line to your shell profile file (e.g. ~/.bashrc, ~/.zshrc, etc.)"
       echo "export PATH=\$PATH:$PREFERRED_BIN_FOLDER"


### PR DESCRIPTION
resolves #403 

here's how i tested this:

```bash
#!/usr/bin/env bash

echo "testing (part of) scaf installer ensure_bin_folder..."

DUMMY_PATH="/usr/local/bin:/opt/homebrew/sbin:/Users/foo/.pyenv/shims:/usr/bin:/bin:/usr/sbin:/sbin"

# shellcheck disable=SC2237
if ! [ -n "$DUMMY_PATH" ] && [ -n "$HOME" ] && echo "$DUMMY_PATH" | grep -q ":$HOME/.local/bin:"; then
  echo "...current: PASS" # should detect missing $HOME/.local/bin in $PATH
else
  echo "...current: FAIL"
fi

# break it down to just the $PATH check.

# shellcheck disable=SC2237
if ! [ -n "$NO_PATH" ]; then
  echo "...nopath: detected empty path"
else
  echo "...nopath: did not detect empty path"
fi

if [ -z "$NO_PATH" ]; then
  echo "...linted nopath: detected empty path"
else
  echo "...linted nopath: did not detect empty path"
fi

# linted from here on out.

# try adding on the $HOME check.

if [ -z "$DUMMY_PATH" ] && [ -z "$NO_HOME" ]; then
  echo "...dummypath and nohome: detected empty home"
else
  echo "...dummypath and nohome: did not detect empty home"
fi

if [ -z "$NO_PATH" ] && [ -z "$HOME" ]; then
  echo "...nopath and home: detected empty path"
else
  echo "...nopath and home: did not detect empty path"
fi

# && means $PATH and $HOME must be missing to fail the check,
# but we can't test if either are missing, so ||, not &&.

if [ -z "$DUMMY_PATH" ] || [ -z "$NO_HOME" ]; then
  echo "...dummypath or nohome: detected empty home"
else
  echo "...dummypath or nohome: did not detect empty home"
fi

if [ -z "$NO_PATH" ] || [ -z "$HOME" ]; then
  echo "...nopath or home: detected empty path"
else
  echo "...nopath or home: did not detect empty path"
fi

# || from here on.

# add grep for dir in path string.

if [ -z "$DUMMY_PATH" ] || [ -z "$HOME" ] || ! echo "$DUMMY_PATH" | grep -q ":$HOME/.local/bin:"; then
  echo "...current grep: detected dir with leading and trailing colons."
else
  echo "...current grep: did not detect dir with leading and trailing colons."
fi

# ok, what if the dir is at the start or end of the path string?

START="$HOME/.local/bin:foo:bar"
MIDDLE="foo:$HOME/.local/bin:bar"
END="foo:bar:$HOME/.local/bin"

CURRENT_EXPRESSION=":$HOME/.local/bin:"

# -E is necessary for "?" to work in the new regex, and the option was included
# with the current expression to hopefully test apples to apples.

if echo "$START" | grep -qE "$CURRENT_EXPRESSION"; then
  echo "...grep: current expression detects dir at path start"
else
  echo "...grep: current expression does not detect dir at path start"
fi

# we already knew this from before, but for completeness...
if echo "$MIDDLE" | grep -qE "$CURRENT_EXPRESSION"; then
  echo "...grep: current expression detects dir in middle of path"
else
  echo "...grep: current expression does not detect dir in middle of path"
fi

if echo "$END" | grep -qE "$CURRENT_EXPRESSION"; then
  echo "...grep: current expression detects dir in middle of path"
else
  echo "...grep: current expression does not detect dir in middle of path"
fi

NEW_EXPRESSION=":?$HOME/.local/bin:?"

if echo "$START" | grep -qE "$NEW_EXPRESSION"; then
  echo "...grep: updated expression detects dir at path start"
else
  echo "...grep: updated expression does not detect dir at path start"
fi

if echo "$MIDDLE" | grep -qE "$NEW_EXPRESSION"; then
  echo "...grep: updated expression detects dir in middle of path"
else
  echo "...grep: updated expression does not detect dir in middle of path"
fi

if echo "$END" | grep -qE "$NEW_EXPRESSION"; then
  echo "...grep: updated expression detects dir in middle of path"
else
  echo "...grep: updated expression does not detect dir in middle of path"
fi

if [ -z "$DUMMY_PATH" ] || [ -z "$HOME" ] || ! echo "$DUMMY_PATH" | grep -qE "$NEW_EXPRESSION"; then
  echo "...new: PASS"
else
  echo "...new: FAIL"
fi

echo "...done."
```