### PR TITLE
docs: reorganize next steps and dependencies sections + fix typos

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/development.md
+++ b/{{cookiecutter.project_slug}}/docs/development.md
@@ -53,7 +53,7 @@ To switch between different Scaf project contexts:
 ## Next steps
 
 Creating a superuser account in the backend is useful so you have access to
-Django Admin that will be accesible at [http://localhost:8009/admin](http://localhost:8009/admin)
+Django Admin that will be accesible at [http://localhost:8000/admin](http://localhost:8000/admin)
 
 To create a superuser use the following commands:
 

--- a/{{cookiecutter.project_slug}}/docs/development.md
+++ b/{{cookiecutter.project_slug}}/docs/development.md
@@ -53,7 +53,7 @@ To switch between different Scaf project contexts:
 ## Next steps
 
 Creating a superuser account in the backend is useful so you have access to
-Django Admin that will be accesible at [http://localhost:8000/admin](http://localhost:8000/admin)
+Django Admin that will be accessible at [http://localhost:8000/admin](http://localhost:8000/admin)
 
 To create a superuser use the following commands:
 

--- a/{{cookiecutter.project_slug}}/docs/development.md
+++ b/{{cookiecutter.project_slug}}/docs/development.md
@@ -50,14 +50,6 @@ To switch between different Scaf project contexts:
       $ make setup   # inside the codebase of the project you want to work on
       $ tilt up
 
-## Update dependencies
-
-To update the backend app dependencies, you must edit the `backend/requirements/*.in` files.
-Once you have made your changes, you need to regenerate the `backend/requirements/*.txt` files using:
-
-       $ make compile
-
-
 ## Next steps
 
 Creating a superuser account in the backend is useful so you have access to
@@ -70,3 +62,10 @@ To create a superuser use the following commands:
 {% if cookiecutter.create_nextjs_frontend == 'y' %}
 This project has a NextJS frontend configured. You can access it at [http://localhost:3000/](http://localhost:3000/).
 {% endif %}
+
+## Update dependencies
+
+To update the backend app dependencies, you must edit the `backend/requirements/*.in` files.
+Once you have made your changes, you need to regenerate the `backend/requirements/*.txt` files using:
+
+       $ make compile


### PR DESCRIPTION
Small change but useful:
Before the next steps came after the dependencies so while going through the first setup, one might miss the next steps, stopping at the dependency update.
Now the sections follow the practical steps one would follow.

Also a couple of small typos fixed.