### PR TITLE
docs: add qa markdown page

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -24,7 +24,7 @@ See [docs/debug.md](/docs/debug.md)
 
 ## :test_tube: How to test the application
 
-See [docs/debug.md](/docs/qa.md)
+See [docs/qa.md](/docs/qa.md)
 
 ## :microscope: How to monitor the application
 

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -22,6 +22,10 @@ See [docs/secrets.md](/docs/secrets.md)
 
 See [docs/debug.md](/docs/debug.md)
 
+## :test_tube: How to test the application
+
+See [docs/debug.md](/docs/qa.md)
+
 ## :microscope: How to monitor the application
 
 See [docs/monitoring.md](/docs/monitoring.md)

--- a/{{cookiecutter.project_slug}}/docs/qa.md
+++ b/{{cookiecutter.project_slug}}/docs/qa.md
@@ -1,0 +1,3 @@
+# :test_tube: How to test the application
+
+TODO: Document all the testing and QA processes.


### PR DESCRIPTION
It was missing. We need a place to store our smoke tests for example.