### PR TITLE
feat: move scaf tasks to corresponding templates #480

### DIFF
--- a/scaf
+++ b/scaf
@@ -121,7 +121,6 @@ if [ -z "$REPO_URL" ]; then
   echo "2) AWS Lambda App Template"
   echo -n "Enter the number corresponding to your choice (1 or 2): "
   read -r template_choice
-  TEMPLATE_CHOICE=$template_choice
 
   case $template_choice in
     1)
@@ -133,7 +132,6 @@ if [ -z "$REPO_URL" ]; then
     *)
       echo "Invalid choice. Using default SFU Full Stack Template."
       REPO_URL="https://github.com/sixfeetup/scaf-aws-lambda-app-template.git"
-      TEMPLATE_CHOICE=1
       ;;
   esac
 fi

--- a/scaf
+++ b/scaf
@@ -138,69 +138,14 @@ if [ -z "$REPO_URL" ]; then
   esac
 fi
 
-
-party_popper() {
-  for i in {1..4}; do
-      echo -ne "\r🎉 POP! 💥"
-      sleep 0.3
-      echo -ne "\r💥 POP! 🎉"
-      sleep 0.3
-  done
-  echo -e "\r🎊 Congrats! Your $PROJECT_SLUG project is ready! 🎉"
-  echo
-  echo "To get started, run:"
-  echo "cd $PROJECT_SLUG"
-  echo "tilt up"
-  echo
-}
-
-run_lambda_template_tasks() {
-  cd "$COPIER_SLUG" || exit 1
-  echo "Running AWS SAM build and validate..."
-  if ! command -v sam &>/dev/null; then
-    echo "Error: AWS SAM CLI is not installed. Please install it and try again."
-    exit 1
-  fi
-  sam build
-  sam validate --lint
-  echo "AWS Lambda template setup complete."
-}
-
-if [[ "$SCAF_CHALLENGE" == "y" ]]; then
-  start_challenge_oauthflow
-  if [[ -f "$CHALLENGE_CONFIG_PATH" ]]; then
-    start_challenge_session
-  else
-    # Force skip challenge as it cannot be started without config file
-    SCAF_CHALLENGE="n"
-  fi
-else
-  echo "Skipping challenge."
-fi
-
 echo "COPIER_OPTIONS: $COPIER_OPTIONS"
 echo "REPO_URL: $REPO_URL"
-
 
 echo "Creating your project..."
 uv run --with isort,black,copier copier copy $COPIER_OPTIONS $REPO_URL . --trust -d "is_project_slug=$COPIER_SLUG"
 
-# Check if copier was successful
-if [ $? -eq 0 ]; then
-  if [ "$TEMPLATE_CHOICE" == "1" ]; then
-    kind create cluster --name $CLUSTER_SLUG
-    cd $COPIER_SLUG
-    make compile
-    echo "Dependencies compiled successfully."
-    pwd
-    echo "Performing initial commit."
-    git add .
-    git commit -m "Initial commit"
-    party_popper
-  else
-    run_lambda_template_tasks
-  fi
-else
+# Check if copier command failed
+if [ $? -ne 0 ]; then
   echo "Failed to create project."
   exit 1
 fi

--- a/scaf
+++ b/scaf
@@ -121,6 +121,7 @@ if [ -z "$REPO_URL" ]; then
   echo "2) AWS Lambda App Template"
   echo -n "Enter the number corresponding to your choice (1 or 2): "
   read -r template_choice
+  TEMPLATE_CHOICE=$template_choice
 
   case $template_choice in
     1)
@@ -132,6 +133,7 @@ if [ -z "$REPO_URL" ]; then
     *)
       echo "Invalid choice. Using default SFU Full Stack Template."
       REPO_URL="https://github.com/sixfeetup/scaf-aws-lambda-app-template.git"
+      TEMPLATE_CHOICE=1
       ;;
   esac
 fi
@@ -152,6 +154,29 @@ party_popper() {
   echo
 }
 
+run_lambda_template_tasks() {
+  cd "$COPIER_SLUG" || exit 1
+  echo "Running AWS SAM build and validate..."
+  if ! command -v sam &>/dev/null; then
+    echo "Error: AWS SAM CLI is not installed. Please install it and try again."
+    exit 1
+  fi
+  sam build
+  sam validate --lint
+  echo "AWS Lambda template setup complete."
+}
+
+if [[ "$SCAF_CHALLENGE" == "y" ]]; then
+  start_challenge_oauthflow
+  if [[ -f "$CHALLENGE_CONFIG_PATH" ]]; then
+    start_challenge_session
+  else
+    # Force skip challenge as it cannot be started without config file
+    SCAF_CHALLENGE="n"
+  fi
+else
+  echo "Skipping challenge."
+fi
 
 echo "COPIER_OPTIONS: $COPIER_OPTIONS"
 echo "REPO_URL: $REPO_URL"
@@ -162,15 +187,19 @@ uv run --with isort,black,copier copier copy $COPIER_OPTIONS $REPO_URL . --trust
 
 # Check if copier was successful
 if [ $? -eq 0 ]; then
-  kind create cluster --name $CLUSTER_SLUG
-  cd $COPIER_SLUG
-  make compile
-  echo "Dependencies compiled successfully."
-  pwd
-  echo "Performing initial commit."
-  git add .
-  git commit -m "Initial commit"
-  party_popper
+  if [ "$TEMPLATE_CHOICE" == "1" ]; then
+    kind create cluster --name $CLUSTER_SLUG
+    cd $COPIER_SLUG
+    make compile
+    echo "Dependencies compiled successfully."
+    pwd
+    echo "Performing initial commit."
+    git add .
+    git commit -m "Initial commit"
+    party_popper
+  else
+    run_lambda_template_tasks
+  fi
 else
   echo "Failed to create project."
   exit 1


### PR DESCRIPTION
## :dart: What needed to be done and why?

Ticket: #480
AWS Lambda app template should successfully run through scaf [#480](https://github.com/sixfeetup/scaf/issues/480)

Right now, when a user scaffold AWS Lambda template, it tries to run the default full-stack-template setup on it and errors out.

## :new: What is changed by this PR?

Scaf is updated so that it can handle aws lambda template and build it

## :clipboard: Code Review Cheatsheet

<details>

<summary>What the reviewer should check</summary>

| Check  | Description |
| ------------- | ------------- |
| :truck: **Diff size** | Is the PR small and focused, or should it be broken into smaller PRs?
| :test_tube: **Unit tests** | Are new features covered with appropriate unit tests?
| :lab_coat: **Acceptance Criteria met** | Are the Acceptance Criteria listed in the issue met?
| :monocle_face: **Code clarity** | Is the code easy to understand? Are variable and function names meaningful?
| :jigsaw: **Code organization** | Are files, modules, and functions structured logically?
| :carpentry_saw: **Conciseness** | Is the code free of unnecessary complexity or redundant code?
| :speech_balloon: **Comments & documentation** | Are code comments explaining *why* and not *how*? Is the documentation up-to-date?
| :abacus: **Code consistency** | Does the code follow existing patterns and conventions in the project?
| :biohazard: **Function length** | Are functions too long? Should they be broken into smaller, more focused functions?
| :radioactive: **Class design** | Are classes well-structured and not overly large or doing too much?
| :paw_prints: **Logging and debugging statements** | Are print/debug statements removed or replaced with proper logging?

</details>
