### PR TITLE
fix: restore semantic release permissions and GITHUB_TOKEN

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   semantic-release:
     runs-on: ubuntu-latest
@@ -35,7 +39,4 @@ jobs:
       - name: Run Semantic Release
         run: npx semantic-release
         env:
-          GIT_AUTHOR_NAME: ${{ github.actor }}
-          GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com
-          GIT_COMMITTER_NAME: ${{ github.actor }}
-          GIT_COMMITTER_EMAIL: ${{ github.actor }}@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* The deploy key (via SSH) is used for git operations like pushing commits and tags
* The GITHUB_TOKEN is used for API operations like creating releases and commenting on issues